### PR TITLE
Source image dimensions are cropped at 400x300 pixels

### DIFF
--- a/lib/scripts/stats.js
+++ b/lib/scripts/stats.js
@@ -23,13 +23,12 @@ _.map(imgs, function getStats (img, cb) {
   // Load in the image
   // DEV: If this fails, use data/html
   var page = webpage.create();
-
   page.open(img, function (status) {
     // Pluck out the image dimensions
     var dimensions = page.evaluate(function () {
       // Grab the image
       var img = document.getElementsByTagName('img')[0];
-      
+
        // remove the default resizing behaviour from the image
       ['style', 'width', 'height'].forEach(function (attr) {
         img.removeAttribute(attr);


### PR DESCRIPTION
Since stats.js opens the image directly on a default phantom viewport, the dimensions are clipped at 400x300.

setting phantom viewport to a larger size fixes the issue.

PhantomJS won't fix this https://github.com/ariya/phantomjs/issues/10191, so we need to set viewportSize.
