### PR TITLE
fix phantomjssmith for node 0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "obj-extend": "~0.1.0",
-    "temporary": "0.0.5",
+    "temporary": "0.0.8",
     "async": "~0.2.7",
     "which": "~1.0.5",
     "shell-quote": "~1.4.0",


### PR DESCRIPTION
On node 0.11, this module fails with this error

```
TypeError: Object.isSealed called on non-object
    at Function.isSealed (native)
    at normalize ([SOME_PATH]/node_modules/temporary/lib/detector.js:23:34)
    at Object.detector.tmp ([SOME_PATH]/node_modules/temporary/lib/detector.js:43:10)
    at Object.generator.build ([SOME_PATH]/node_modules/temporary/lib/generator.js:45:27)
    at File.Base.init ([SOME_PATH]/node_modules/temporary/lib/base.js:31:28)
    at new File ([SOME_PATH]/node_modules/temporary/lib/file.js:23:8)
    at Object.createImages ([SOME_PATH]/lib/image.js:6:13)
```

this was fixed in the `temporary` package already: https://github.com/vesln/temporary/commit/f9fc8cb5f6f8bfc7bfcc868e5102033e1a6e6305

switching to that version of `temporary` fixes phantomjssmith on node 0.11
